### PR TITLE
Nhse o34 orkv.i70 case insensitive

### DIFF
--- a/include/raw_http.hrl
+++ b/include/raw_http.hrl
@@ -40,6 +40,14 @@
 -define(HEAD_INDEX_PREFIX,    "X-Riak-Index-").
 -define(HEAD_IF_NOT_MODIFIED, "X-Riak-If-Not-Modified").
 
+-define(LOWER_CTYPE,           <<"content-type">>).
+-define(LOWER_VCLOCK,          <<"x-riak-vclock">>).
+-define(LOWER_LINK,            <<"link">>).
+-define(LOWER_USERMETA_PREFIX, "x-riak-meta-").
+-define(LOWER_INDEX_PREFIX,    "x-riak-index-").
+-define(LOWER_VTAG,            <<"etag">>).
+-define(LOWER_LMD,             <<"last-modified">>).
+
 %%======================================================================
 %% JSON keys/values
 %%======================================================================

--- a/src/rhc.erl
+++ b/src/rhc.erl
@@ -1709,7 +1709,11 @@ update_type(Rhc, BucketAndType, Key, {Type, Op, Context}, Options) ->
         {ok, "201", Headers, RBody} ->
             %% Riak-assigned key
             Url = proplists:get_value("Location", Headers),
-            Key = unicode:characters_to_binary(lists:last(string:tokens(Url, "/")), utf8),
+            Key =
+                unicode:characters_to_binary(
+                    lists:last(string:lexemes(Url, "/")),
+                    utf8
+                ),
             case proplists:get_value("Content-Length", Headers) of
                 "0" ->
                     {ok, Key};

--- a/src/rhc_obj.erl
+++ b/src/rhc_obj.erl
@@ -28,7 +28,6 @@
 
 -include("raw_http.hrl").
 -include("rhc.hrl").
--include_lib("stdlib/include/assert.hrl").
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -196,7 +195,7 @@ extract_links(HeaderMap) ->
                 end
         end,
     LinkHeader = maps:get(?HEAD_LINK, HeaderMap, []),
-    lists:foldl(Extractor, [], string:tokens(LinkHeader, ",")).
+    lists:foldl(Extractor, [], string:lexemes(LinkHeader, ",")).
 
 extract_indexes(HeaderMap) ->
     lists:flatten(

--- a/src/rhc_obj.erl
+++ b/src/rhc_obj.erl
@@ -28,6 +28,11 @@
 
 -include("raw_http.hrl").
 -include("rhc.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
 
 %% HTTP -> riakc_obj
 
@@ -121,8 +126,23 @@ accumulate_header_info(_DiscardIdx, _OK, _Value, MapAcc) ->
     MapAcc.
 
 headers_to_metadata(HeaderMap) ->
-    UserMeta =
-        dict:from_list(maps:get(<<?LOWER_USERMETA_PREFIX>>, HeaderMap, [])),
+    UserMetaKVL = maps:get(<<?LOWER_USERMETA_PREFIX>>, HeaderMap, []),
+    UserMeta = 
+        lists:foldl(
+            fun({K, V}, Acc) ->
+                VBin =
+                    case V of
+                        VL when is_list(VL) ->
+                            list_to_binary(VL);
+                        VB when is_binary(VB) ->
+                            VB
+                    end,
+                riakc_obj:set_user_metadata_entry(Acc, {K, VBin})
+            end,
+            dict:new(),
+            UserMetaKVL
+        ),
+    
 
     {CType,_} = maps:get(?LOWER_CTYPE, HeaderMap),
     CUserMeta = dict:store(?MD_CTYPE, CType, UserMeta),
@@ -153,7 +173,7 @@ headers_to_metadata(HeaderMap) ->
     end,
     case extract_indexes(HeaderMap) of
         [] -> LinkMeta;
-        Entries -> dict:store(?MD_INDEX, Entries, LinkMeta)
+        Entries -> dict:store(?MD_INDEX, lists:reverse(Entries), LinkMeta)
     end.
 
 
@@ -172,19 +192,22 @@ extract_links(HeaderMap) ->
     lists:foldl(Extractor, [], string:tokens(LinkHeader, ",")).
 
 extract_indexes(HeaderMap) ->
-    lists:map(
-        fun({F, V}) ->
-            {F, decode_index_value(F, V)}
-        end,
-        maps:get(<<?LOWER_INDEX_PREFIX>>, HeaderMap, [])
+    lists:flatten(
+        lists:map(
+            fun({F, V}) ->
+                decode_index_value(F, V)
+            end,
+            maps:get(<<?LOWER_INDEX_PREFIX>>, HeaderMap, [])
+        )
     ).
 
 decode_index_value(K, V) ->
+    TL = lists:reverse(string:split(V, ", ", all)),
     case lists:last(string:lexemes(K, "_")) of
         <<"bin">> ->
-            list_to_binary(V);
+            lists:map(fun(T) -> {K, list_to_binary(T)} end, TL);
         <<"int">> ->
-            list_to_integer(V)
+            lists:map(fun(T) -> {K, list_to_integer(T)} end, TL)
     end.
 
 serialize_riakc_obj(Rhc, Object) ->
@@ -249,3 +272,56 @@ make_body(Object) ->
         Val when is_binary(Val) -> 
             Val
     end.
+
+-ifdef(TEST).
+
+headers_test() ->
+    HeaderList =
+        [
+            {"x-riak-index-field1_bin", "I0001, I0002"},
+            {"x-riak-index-field2_int", "1, 2"},
+            {"X-Riak-Index-field3_bin", "I0003"},
+            {"x-riak-meta-K0001", "V0001"},
+            {"x-riak-meta-K0002", "V0002"},
+            {"ETag", "abc123"},
+            {"content-type", "application/json"}
+        ],
+    HeaderMap = make_rspheader_map(HeaderList),
+    Metadata = headers_to_metadata(HeaderMap),
+    ExpectedMetadata =
+        dict:from_list(
+            [
+                {
+                    <<"X-Riak-Meta">>,
+                    [
+                        {<<"K0001">>,<<"V0001">>},
+                        {<<"K0002">>,<<"V0002">>}
+                    ]
+                },
+                {
+                    <<"index">>,
+                    [
+                        {<<"field1_bin">>,<<"I0001">>},
+                        {<<"field1_bin">>,<<"I0002">>},
+                        {<<"field2_int">>, 1},
+                        {<<"field2_int">>, 2},
+                        {<<"field3_bin">>,<<"I0003">>}
+                    ]
+                },
+                {
+                    <<"content-type">>,
+                    "application/json"
+                },
+                {
+                    <<"X-Riak-VTag">>,
+                    "abc123"
+                }
+            ]
+        ),
+    ?assertMatch(
+        ExpectedMetadata,
+        Metadata
+    ).
+
+
+-endif.

--- a/src/rhc_obj.erl
+++ b/src/rhc_obj.erl
@@ -24,9 +24,7 @@
 %%      translating between HTTP (ibrowse) data and riakc_obj objects.
 -module(rhc_obj).
 
--export([make_riakc_obj/4,
-         serialize_riakc_obj/2,
-         ctype_from_headers/1]).
+-export([make_riakc_obj/4, serialize_riakc_obj/2, ctype_from_headers/1]).
 
 -include("raw_http.hrl").
 -include("rhc.hrl").
@@ -34,112 +32,160 @@
 %% HTTP -> riakc_obj
 
 make_riakc_obj(Bucket, Key, Headers, Body) ->
-    Vclock = base64:decode(proplists:get_value(?HEAD_VCLOCK, Headers, "")),
-    case ctype_from_headers(Headers) of
+    HeaderMap = make_rspheader_map(Headers),
+    Vclock = maps:get(?LOWER_VCLOCK, HeaderMap, ""),
+    case maps:get(?LOWER_CTYPE, HeaderMap) of
         {"multipart/mixed", Args} ->
             {"boundary", Boundary} = proplists:lookup("boundary", Args),
             riakc_obj:new_obj(
-              Bucket, Key, Vclock,
-              decode_siblings(Boundary, Body));
+                Bucket,
+                Key,
+                Vclock,
+                decode_siblings(Boundary, Body)
+            );
         {_CType, _} ->
             riakc_obj:new_obj(
-              Bucket, Key, Vclock,
-              [{headers_to_metadata(Headers), Body}])
+                Bucket,
+                Key,
+                Vclock,
+                [{headers_to_metadata(HeaderMap), Body}]
+            )
     end.
 
 ctype_from_headers(Headers) ->
     mochiweb_util:parse_header(
       proplists:get_value(?HEAD_CTYPE, Headers)).
 
-vtag_from_headers(Headers) ->
-    %% non-sibling uses ETag, sibling uses Etag
-    %% (note different capitalization on 't')
-    case proplists:lookup("ETag", Headers) of
-        {"ETag", ETag} -> ETag;
-        none -> proplists:get_value("Etag", Headers)
-    end.
-
-
-lastmod_from_headers(Headers) ->
-    case proplists:get_value("Last-Modified", Headers) of
-        undefined ->
-            undefined;
-        RfcDate ->
-            GS = calendar:datetime_to_gregorian_seconds(
-                   httpd_util:convert_request_date(RfcDate)),
-            ES = GS-62167219200, %% gregorian seconds of the epoch
-            {ES div 1000000, % Megaseconds
-             ES rem 1000000, % Seconds
-             0}              % Microseconds
-    end.
-
 decode_siblings(Boundary, <<"\r\n",SibBody/binary>>) ->
     decode_siblings(Boundary, SibBody);
 decode_siblings(Boundary, SibBody) ->
-    Parts = webmachine_multipart:get_all_parts(
-              SibBody, Boundary),
-    [ {headers_to_metadata([ {binary_to_list(H), binary_to_list(V)}
-                             || {H, V} <- Headers ]),
-       element(1, split_binary(Body, size(Body)))}
-      || {_, {_, Headers}, Body} <- Parts ].
+    lists:map(
+        fun({_, {_, Headers}, Body}) ->
+            HeaderMap = make_rspheader_map(Headers),
+            {
+                headers_to_metadata(HeaderMap),
+                element(1, split_binary(Body, size(Body)))
+            }
+        end,
+        webmachine_multipart:get_all_parts(SibBody, Boundary)
+    ).
 
-headers_to_metadata(Headers) ->
-    UserMeta = extract_user_metadata(Headers),
+make_rspheader_map(Headers) ->
+    lists:foldl(
+        fun({HeadKey, HeadVal}, AccMap) ->
+            BinHeadKey =
+                case HeadKey of
+                    HeadKey when is_binary(HeadKey) ->
+                        HeadKey;
+                    HeadKey when is_list(HeadKey) ->
+                        list_to_binary(HeadKey)
+                end,
+            accumulate_header_info(
+                string:lowercase(BinHeadKey),
+                HeadKey,
+                HeadVal,
+                AccMap
+            )
+        end,
+        maps:new(),
+        Headers
+    ).
 
-    {CType,_} = ctype_from_headers(Headers),
+accumulate_header_info(<<?LOWER_INDEX_PREFIX, _Field/binary>>, OriginalKey, T, MapAcc) ->
+    <<_Prefix:13/binary, Field/binary>> = OriginalKey,
+    maps:update_with(
+        <<?LOWER_INDEX_PREFIX>>,
+        fun(Indices) -> [{Field, T}|Indices] end,
+        [{Field, T}],
+        MapAcc
+    );
+accumulate_header_info(<<?LOWER_USERMETA_PREFIX, _MetaKey/binary>>, OriginalKey, V, MapAcc) ->
+    <<_Prefix:12/binary, MetaKey/binary>> = OriginalKey,
+    maps:update_with(
+        <<?LOWER_USERMETA_PREFIX>>,
+        fun(Indices) -> [{MetaKey, V}|Indices] end,
+        [{MetaKey, V}],
+        MapAcc
+    );
+accumulate_header_info(?LOWER_CTYPE, _OK, V, MapAcc) ->
+    maps:put(?LOWER_CTYPE, mochiweb_util:parse_header(V), MapAcc);
+accumulate_header_info(?LOWER_VTAG, _OK, V, MapAcc) ->
+    maps:put(?LOWER_VTAG, V, MapAcc);
+accumulate_header_info(?LOWER_VCLOCK, _OK, VC, MapAcc) ->
+    maps:put(?LOWER_VCLOCK, base64:decode(VC), MapAcc);
+accumulate_header_info(?LOWER_LINK, _OK, V, MapAcc) ->
+    maps:put(?LOWER_LINK, V, MapAcc);
+accumulate_header_info(?LOWER_LMD, _OK, V, MapAcc) ->
+    maps:put(?LOWER_LMD, V, MapAcc);
+accumulate_header_info(_DiscardIdx, _OK, _Value, MapAcc) ->
+    MapAcc.
+
+headers_to_metadata(HeaderMap) ->
+    UserMeta =
+        dict:from_list(maps:get(<<?LOWER_USERMETA_PREFIX>>, HeaderMap, [])),
+
+    {CType,_} = maps:get(?LOWER_CTYPE, HeaderMap),
     CUserMeta = dict:store(?MD_CTYPE, CType, UserMeta),
 
-    VTag = vtag_from_headers(Headers),
+    VTag = maps:get(?LOWER_VTAG, HeaderMap),
     VCUserMeta = dict:store(?MD_VTAG, VTag, CUserMeta),
 
-    LVCUserMeta = case lastmod_from_headers(Headers) of
-                      undefined ->
-                          VCUserMeta;
-                      LastMod ->
-                          dict:store(?MD_LASTMOD, LastMod, VCUserMeta)
-                  end,
+    LVCUserMeta =
+        case maps:get(?LOWER_LMD, HeaderMap, undefined) of
+            undefined ->
+                VCUserMeta;
+            RfcDate ->
+                GS =
+                    calendar:datetime_to_gregorian_seconds(
+                        httpd_util:convert_request_date(RfcDate)
+                    ),
+                ES = GS-62167219200, %% gregorian seconds of the epoch
+                dict:store(
+                    ?MD_LASTMOD,
+                    {ES div 1000000, ES rem 1000000, 0},
+                    VCUserMeta
+                )
+        end,
 
-    LinkMeta = case extract_links(Headers) of
+    LinkMeta = case extract_links(HeaderMap) of
         [] -> LVCUserMeta;
         Links -> dict:store(?MD_LINKS, Links, LVCUserMeta)
     end,
-    case extract_indexes(Headers) of
+    case extract_indexes(HeaderMap) of
         [] -> LinkMeta;
         Entries -> dict:store(?MD_INDEX, Entries, LinkMeta)
     end.
 
-extract_user_metadata(Headers) ->
-    lists:foldl(fun extract_user_metadata/2, dict:new(), Headers).
 
-extract_user_metadata({?HEAD_USERMETA_PREFIX++K, V}, Dict) ->
-    riakc_obj:set_user_metadata_entry(Dict, {K, V});
-extract_user_metadata(_, D) -> D.
-
-extract_links(Headers) ->
+extract_links(HeaderMap) ->
     {ok, Re} = re:compile("</[^/]+/([^/]+)/([^/]+)>; *riaktag=\"(.*)\""),
-    Extractor = fun(L, Acc) ->
-                        case re:run(L, Re, [{capture,[1,2,3],binary}]) of
-                            {match, [Bucket, Key,Tag]} ->
-                                [{{Bucket,Key},Tag}|Acc];
-                            nomatch ->
-                                Acc
-                        end
-                end,
-    LinkHeader = proplists:get_value(?HEAD_LINK, Headers, []),
+    Extractor =
+        fun(L, Acc) ->
+                case re:run(L, Re, [{capture,[1,2,3],binary}]) of
+                    {match, [Bucket, Key,Tag]} ->
+                        [{{Bucket,Key},Tag}|Acc];
+                    nomatch ->
+                        Acc
+                end
+        end,
+    LinkHeader = maps:get(?HEAD_LINK, HeaderMap, []),
     lists:foldl(Extractor, [], string:tokens(LinkHeader, ",")).
 
-extract_indexes(Headers) ->
-    [ {list_to_binary(K), decode_index_value(K,V)} || {?HEAD_INDEX_PREFIX++K, V} <- Headers].
+extract_indexes(HeaderMap) ->
+    lists:map(
+        fun({F, V}) ->
+            {F, decode_index_value(F, V)}
+        end,
+        maps:get(<<?LOWER_INDEX_PREFIX>>, HeaderMap, [])
+    ).
 
 decode_index_value(K, V) ->
-    case lists:last(string:tokens(K, "_")) of
-        "bin" ->
+    case lists:last(string:lexemes(K, "_")) of
+        <<"bin">> ->
             list_to_binary(V);
-        "int" ->
+        <<"int">> ->
             list_to_integer(V)
     end.
-
-%% riakc_obj -> HTTP
 
 serialize_riakc_obj(Rhc, Object) ->
     {make_headers(Rhc, Object), make_body(Object)}.

--- a/src/rhc_obj.erl
+++ b/src/rhc_obj.erl
@@ -85,10 +85,17 @@ make_rspheader_map(Headers) ->
                     HeadKey when is_list(HeadKey) ->
                         list_to_binary(HeadKey)
                 end,
+            ListHeadVal =
+                case HeadVal of
+                    HeadVal when is_binary(HeadVal) ->
+                        binary_to_list(HeadVal);
+                    HeadVal when is_list(HeadVal) ->
+                        HeadVal
+                end,
             accumulate_header_info(
                 string:lowercase(BinHeadKey),
                 BinHeadKey,
-                HeadVal,
+                ListHeadVal,
                 AccMap
             )
         end,
@@ -112,9 +119,7 @@ accumulate_header_info(<<?LOWER_USERMETA_PREFIX, _MetaKey/binary>>, OriginalKey,
         [{MetaKey, V}],
         MapAcc
     );
-accumulate_header_info(?LOWER_CTYPE, OK, V, MapAcc) when is_binary(V) ->
-    accumulate_header_info(?LOWER_CTYPE, OK, binary_to_list(V), MapAcc);
-accumulate_header_info(?LOWER_CTYPE, _OK, V, MapAcc) when is_list(V) ->
+accumulate_header_info(?LOWER_CTYPE, _OK, V, MapAcc) ->
     maps:put(?LOWER_CTYPE, mochiweb_util:parse_header(V), MapAcc);
 accumulate_header_info(?LOWER_VTAG, _OK, V, MapAcc) ->
     maps:put(?LOWER_VTAG, V, MapAcc);

--- a/src/rhc_obj.erl
+++ b/src/rhc_obj.erl
@@ -202,7 +202,7 @@ extract_indexes(HeaderMap) ->
     ).
 
 decode_index_value(K, V) ->
-    TL = string:split(V, ", ", all),
+    TL = lists:reverse(string:split(V, ", ", all)),
     case lists:last(string:lexemes(K, "_")) of
         <<"bin">> ->
             lists:map(fun(T) -> {K, list_to_binary(T)} end, TL);
@@ -302,10 +302,10 @@ headers_test() ->
                     <<"index">>,
                     [
                         {<<"field3_bin">>,<<"I0003">>},
-                        {<<"field2_int">>, 1},
                         {<<"field2_int">>, 2},
-                        {<<"field1_bin">>,<<"I0001">>},
-                        {<<"field1_bin">>,<<"I0002">>}
+                        {<<"field2_int">>, 1},
+                        {<<"field1_bin">>,<<"I0002">>},
+                        {<<"field1_bin">>,<<"I0001">>}
                     ]
                 },
                 {

--- a/src/rhc_obj.erl
+++ b/src/rhc_obj.erl
@@ -173,7 +173,7 @@ headers_to_metadata(HeaderMap) ->
     end,
     case extract_indexes(HeaderMap) of
         [] -> LinkMeta;
-        Entries -> dict:store(?MD_INDEX, lists:reverse(Entries), LinkMeta)
+        Entries -> dict:store(?MD_INDEX, Entries, LinkMeta)
     end.
 
 
@@ -202,7 +202,7 @@ extract_indexes(HeaderMap) ->
     ).
 
 decode_index_value(K, V) ->
-    TL = lists:reverse(string:split(V, ", ", all)),
+    TL = string:split(V, ", ", all),
     case lists:last(string:lexemes(K, "_")) of
         <<"bin">> ->
             lists:map(fun(T) -> {K, list_to_binary(T)} end, TL);
@@ -301,11 +301,11 @@ headers_test() ->
                 {
                     <<"index">>,
                     [
-                        {<<"field1_bin">>,<<"I0001">>},
-                        {<<"field1_bin">>,<<"I0002">>},
+                        {<<"field3_bin">>,<<"I0003">>},
                         {<<"field2_int">>, 1},
                         {<<"field2_int">>, 2},
-                        {<<"field3_bin">>,<<"I0003">>}
+                        {<<"field1_bin">>,<<"I0001">>},
+                        {<<"field1_bin">>,<<"I0002">>}
                     ]
                 },
                 {

--- a/src/rhc_obj.erl
+++ b/src/rhc_obj.erl
@@ -112,7 +112,9 @@ accumulate_header_info(<<?LOWER_USERMETA_PREFIX, _MetaKey/binary>>, OriginalKey,
         [{MetaKey, V}],
         MapAcc
     );
-accumulate_header_info(?LOWER_CTYPE, _OK, V, MapAcc) ->
+accumulate_header_info(?LOWER_CTYPE, OK, V, MapAcc) when is_binary(V) ->
+    accumulate_header_info(?LOWER_CTYPE, OK, binary_to_list(V), MapAcc);
+accumulate_header_info(?LOWER_CTYPE, _OK, V, MapAcc) when is_list(V) ->
     maps:put(?LOWER_CTYPE, mochiweb_util:parse_header(V), MapAcc);
 accumulate_header_info(?LOWER_VTAG, _OK, V, MapAcc) ->
     maps:put(?LOWER_VTAG, V, MapAcc);

--- a/src/rhc_obj.erl
+++ b/src/rhc_obj.erl
@@ -82,7 +82,7 @@ make_rspheader_map(Headers) ->
                 end,
             accumulate_header_info(
                 string:lowercase(BinHeadKey),
-                HeadKey,
+                BinHeadKey,
                 HeadVal,
                 AccMap
             )


### PR DESCRIPTION
Handles response headers in a case insensitive way - and returns as close as possible to same `riakc_obj` as returned in PB API.

Tested via the `metadata_version_change` test - https://github.com/OpenRiak/riak_test/pull/14